### PR TITLE
Fix referencing issues of Fish and Tank

### DIFF
--- a/src/main/java/seedu/address/logic/commands/fish/FishAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/fish/FishAddCommand.java
@@ -71,6 +71,8 @@ public class FishAddCommand extends FishCommand {
         requireNonNull(tank);
         // assigns fish to tank
         toAdd.setTank(tank);
+        //each tank has individual fishlist/addressbook
+        tank.addFish(toAdd);
 
         model.addFish(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -45,10 +45,35 @@ public class ModelManager implements Model {
         filteredTasks = new FilteredList<>(this.taskList.getTaskList());
         this.tankList = new TankList(tankList);
         filteredTanks = new FilteredList<>(this.tankList.getTankList());
+
+        updateTanksOfEachFishAndFishListOfEachTank();
     }
 
     public ModelManager() {
         this(new AddressBook(), new UserPrefs(), new TaskList(), new TankList());
+    }
+
+    /**
+     * Points the {@code Tank} attribute of a Fish to the correct instance of {@code Tank}
+     * and sets each {@code Fish} in the fishlist/addressbook of a tank to the correct instance
+     */
+    public void updateTanksOfEachFishAndFishListOfEachTank() {
+        for (Fish f : addressBook.getFishList()) {
+            Tank t = f.getTank();
+            Tank realInstance = getTankListTankInstance(t);
+            requireNonNull(realInstance);
+            realInstance.getFishList().addFish(f);
+            f.setTank(realInstance);
+        }
+    }
+
+    public Tank getTankListTankInstance(Tank duplicate) {
+        for (Tank t : tankList.getTankList()) {
+            if (t.equals(duplicate)) {
+                return t;
+            }
+        }
+        return null;
     }
 
     //=========== UserPrefs ==================================================================================
@@ -142,6 +167,7 @@ public class ModelManager implements Model {
     public void addFish(Fish fish) {
         addressBook.addFish(fish);
         updateFilteredFishList(PREDICATE_SHOW_ALL_FISHES);
+
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedTank.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTank.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.tank.Tank;
 import seedu.address.model.tank.TankName;
 
@@ -45,6 +46,6 @@ class JsonAdaptedTank {
             throw new IllegalValueException(TankName.MESSAGE_CONSTRAINTS);
         }
         final TankName modelTankName = new TankName(tankName);
-        return new Tank(modelTankName, null);
+        return new Tank(modelTankName, new AddressBook());
     }
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableTankList.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableTankList.java
@@ -53,8 +53,7 @@ class JsonSerializableTankList {
             if (tankList.hasTank(tank)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_TANK);
             }
-            Tank newTank = new Tank(tank.getTankName(), null);
-            tankList.addTank(newTank);
+            tankList.addTank(tank);
         }
         return tankList;
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -31,9 +31,9 @@ public class AddCommandIntegrationTest {
     @Test
     public void execute_newFish_success() {
         Fish validFish = new FishBuilder().build();
-
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), getTypicalTaskList(),
-                model.getTankList());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(), getTypicalTankList());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
         expectedModel.addFish(validFish);
 
         assertCommandSuccess(new AddCommand(validFish, Index.fromOneBased(1)), model,

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalFishes.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalTanks.getTypicalTankList;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
 
 import org.junit.jupiter.api.Test;
@@ -9,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.TankList;
 import seedu.address.model.UserPrefs;
 
 public class ClearCommandTest {
@@ -24,9 +24,10 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyAddressBook_success() {
-        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(), new TankList());
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
-                new TankList());
+                getTypicalTankList());
         expectedModel.setAddressBook(new AddressBook());
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.showFishAtIndex;
 import static seedu.address.testutil.TypicalFishes.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_FISH;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_FISH;
+import static seedu.address.testutil.TypicalTanks.getTypicalTankList;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.TankList;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.fish.Fish;
 
@@ -27,7 +27,7 @@ import seedu.address.model.fish.Fish;
 public class DeleteCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
-            new TankList());
+            getTypicalTankList());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
@@ -37,7 +37,7 @@ public class DeleteCommandTest {
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_FISH_SUCCESS, fishToDelete);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), getTypicalTaskList(),
-                new TankList());
+                getTypicalTankList());
         expectedModel.deleteFish(fishToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
@@ -61,7 +61,7 @@ public class DeleteCommandTest {
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_FISH_SUCCESS, fishToDelete);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), getTypicalTaskList(),
-                new TankList());
+                getTypicalTankList());
         expectedModel.deleteFish(fishToDelete);
         showNoFish(expectedModel);
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -8,13 +8,14 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_LAST_FED_DATE_B
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SPECIES_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TANK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showFishAtIndex;
 import static seedu.address.testutil.TypicalFishes.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_FISH;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_FISH;
+import static seedu.address.testutil.TypicalTanks.TYPICAL_TANK_2_STRING;
+import static seedu.address.testutil.TypicalTanks.getTypicalTankList;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
 
 import org.junit.jupiter.api.Test;
@@ -25,9 +26,10 @@ import seedu.address.logic.commands.EditCommand.EditFishDescriptor;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.TankList;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.fish.Fish;
+import seedu.address.model.tank.Tank;
+import seedu.address.model.tank.TankName;
 import seedu.address.testutil.EditFishDescriptorBuilder;
 import seedu.address.testutil.FishBuilder;
 
@@ -36,45 +38,49 @@ import seedu.address.testutil.FishBuilder;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
-            new TankList());
+    private Model model;
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                new UserPrefs(),
+                getTypicalTaskList(),
+                getTypicalTankList());
         Fish editedFish = new FishBuilder().build();
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_FISH_SUCCESS, editedFish);
+        //In edit command, a new fish with new tank is created. Since edited fish also belongs in tank index 1,
+        // hard coded 1 here
+        editedFish.setTank(new Tank(new TankName("1"), new AddressBook()));
         EditFishDescriptor descriptor = new EditFishDescriptorBuilder(editedFish).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_FISH, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_FISH_SUCCESS, editedFish);
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                                                                    new UserPrefs(),
-                                                                    getTypicalTaskList(),
-                                                                    new TankList());
-        expectedModel.setFish(model.getFilteredFishList().get(0), editedFish);
+        expectedModel.setFish(expectedModel.getFilteredFishList().get(0), editedFish);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastFish = Index.fromOneBased(model.getFilteredFishList().size());
-        Fish lastFish = model.getFilteredFishList().get(indexLastFish.getZeroBased());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                new UserPrefs(),
+                getTypicalTaskList(),
+                getTypicalTankList());
+        Index indexLastFish = Index.fromOneBased(expectedModel.getFilteredFishList().size());
+        Fish lastFish = expectedModel.getFilteredFishList().get(indexLastFish.getZeroBased());
 
         FishBuilder fishInList = new FishBuilder(lastFish);
         Fish editedFish = fishInList.withName(VALID_NAME_BOB).withLastFedDate(VALID_LAST_FED_DATE_BOB)
-                .withSpecies(VALID_SPECIES_BOB).withTank(VALID_TANK_BOB).withTags(VALID_TAG_HUSBAND).build();
-
-        EditFishDescriptor descriptor = new EditFishDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withLastFedDate(VALID_LAST_FED_DATE_BOB).withSpecies(VALID_SPECIES_BOB).withTank(VALID_TANK_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastFish, descriptor);
+                .withSpecies(VALID_SPECIES_BOB).withTank(TYPICAL_TANK_2_STRING).withTags(VALID_TAG_HUSBAND).build();
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_FISH_SUCCESS, editedFish);
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                                                                    new UserPrefs(),
-                                                                    getTypicalTaskList(), new TankList());
+        //In edit command, a new fish with new tank is created. Since new fish is in tank 2, hard coded 2 here
+        editedFish.setTank(new Tank(new TankName("2"), new AddressBook()));
+        EditFishDescriptor descriptor = new EditFishDescriptorBuilder(editedFish).build();
+        EditCommand editCommand = new EditCommand(indexLastFish, descriptor);
         expectedModel.setFish(lastFish, editedFish);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -82,40 +88,54 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_FISH, new EditFishDescriptor());
-        Fish editedFish = model.getFilteredFishList().get(INDEX_FIRST_FISH.getZeroBased());
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_FISH_SUCCESS, editedFish);
-
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                                                                    new UserPrefs(),
-                                                                    getTypicalTaskList(), new TankList());
+                new UserPrefs(),
+                getTypicalTaskList(),
+                getTypicalTankList());
+        Fish editedFish = new FishBuilder(expectedModel.getFilteredFishList().get(INDEX_FIRST_FISH.getZeroBased()))
+                .build();
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_FISH_SUCCESS, editedFish);
+        //In edit command, a new fish with new tank is created. Since edited fish also belongs in tank index 1,
+        // hard coded 1 here
+        editedFish.setTank(new Tank(new TankName("1"), new AddressBook()));
+        EditFishDescriptor descriptor = new EditFishDescriptorBuilder(editedFish).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_FISH, descriptor);
+        expectedModel.setFish(expectedModel.getFilteredFishList().get(INDEX_FIRST_FISH.getZeroBased()), editedFish);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_filteredList_success() {
-        showFishAtIndex(model, INDEX_FIRST_FISH);
-
-        Fish fishInFilteredList = model.getFilteredFishList().get(INDEX_FIRST_FISH.getZeroBased());
-        Fish editedFish = new FishBuilder(fishInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_FISH,
-                new EditFishDescriptorBuilder().withName(VALID_NAME_BOB).build());
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_FISH_SUCCESS, editedFish);
-
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                                                                    new UserPrefs(),
-                                                                    getTypicalTaskList(), new TankList());
-        expectedModel.setFish(model.getFilteredFishList().get(0), editedFish);
+                new UserPrefs(),
+                getTypicalTaskList(),
+                getTypicalTankList());
+
+        showFishAtIndex(model, INDEX_FIRST_FISH);
+        Fish fishInFilteredList = expectedModel.getFilteredFishList().get(INDEX_FIRST_FISH.getZeroBased());
+        Fish editedFish = new FishBuilder(fishInFilteredList).withName(VALID_NAME_BOB).build();
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_FISH_SUCCESS, editedFish);
+        //In edit command, a new fish with new tank is created. Since edited fish also belongs in tank index 1,
+        // hard coded 1 here
+        editedFish.setTank(new Tank(new TankName("1"), new AddressBook()));
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_FISH,
+                new EditFishDescriptorBuilder(editedFish).build());
+        expectedModel.setFish(expectedModel.getFilteredFishList().get(0), editedFish);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicateFishUnfilteredList_failure() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
         Fish firstFish = model.getFilteredFishList().get(INDEX_FIRST_FISH.getZeroBased());
+        firstFish.setTank(new Tank(new TankName("1"), new AddressBook()));
         EditFishDescriptor descriptor = new EditFishDescriptorBuilder(firstFish).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_FISH, descriptor);
 
@@ -124,10 +144,14 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicateFishFilteredList_failure() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
         showFishAtIndex(model, INDEX_FIRST_FISH);
 
         // edit fish in filtered list into a duplicate in address book
         Fish fishInList = model.getAddressBook().getFishList().get(INDEX_SECOND_FISH.getZeroBased());
+        // user inputs tank attribute will be a number for edit commands
+        fishInList.setTank(new Tank(new TankName("1"), new AddressBook()));
         EditCommand editCommand = new EditCommand(INDEX_FIRST_FISH,
                 new EditFishDescriptorBuilder(fishInList).build());
 
@@ -136,8 +160,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidFishIndexUnfilteredList_failure() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredFishList().size() + 1);
-        EditFishDescriptor descriptor = new EditFishDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        //The fish parameter of edit commands have tank attribute as an index.
+        EditFishDescriptor descriptor = new EditFishDescriptorBuilder().withName(VALID_NAME_BOB).withTank("1").build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_FISH_DISPLAYED_INDEX);
@@ -149,19 +176,24 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidFishIndexFilteredList_failure() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
         showFishAtIndex(model, INDEX_FIRST_FISH);
         Index outOfBoundIndex = INDEX_SECOND_FISH;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getFishList().size());
 
+        //The fish parameter of edit commands have tank attribute as an index.
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditFishDescriptorBuilder().withName(VALID_NAME_BOB).build());
+                new EditFishDescriptorBuilder().withName(VALID_NAME_BOB).withTank("1").build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_FISH_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_FISH, DESC_AMY);
 
         // same values -> returns true

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalFishes.CARL;
 import static seedu.address.testutil.TypicalFishes.ELLE;
 import static seedu.address.testutil.TypicalFishes.FIONA;
 import static seedu.address.testutil.TypicalFishes.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalTanks.getTypicalTankList;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
 
 import java.util.Arrays;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.TankList;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.fish.NameContainsKeywordsPredicate;
 
@@ -27,9 +27,9 @@ import seedu.address.model.fish.NameContainsKeywordsPredicate;
  */
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
-            new TankList());
+            getTypicalTankList());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
-            new TankList());
+            getTypicalTankList());
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showFishAtIndex;
 import static seedu.address.testutil.TypicalFishes.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_FISH;
+import static seedu.address.testutil.TypicalTanks.getTypicalTankList;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.TankList;
 import seedu.address.model.UserPrefs;
 
 /**
@@ -25,8 +25,9 @@ public class ListCommandTest {
 
     @BeforeEach
     public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(), new TankList());
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), getTypicalTaskList(), new TankList());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(), getTypicalTankList());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), getTypicalTaskList(),
+                getTypicalTankList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/tank/TankAddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/tank/TankAddCommandIntegrationTest.java
@@ -32,7 +32,7 @@ public class TankAddCommandIntegrationTest {
         Tank validTank = new TankBuilder().build();
 
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
-                model.getTankList());
+                getTypicalTankList());
         expectedModel.addTank(validTank);
 
         assertCommandSuccess(new TankAddCommand(validTank), model,

--- a/src/test/java/seedu/address/logic/commands/tank/TankDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tank/TankDeleteCommandTest.java
@@ -37,7 +37,7 @@ public class TankDeleteCommandTest {
         String expectedMessage = String.format(TankDeleteCommand.MESSAGE_DELETE_TANK_SUCCESS, tankToDelete);
 
         ModelManager expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
-                model.getTankList());
+                getTypicalTankList());
         expectedModel.deleteTank(tankToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
@@ -61,7 +61,7 @@ public class TankDeleteCommandTest {
         String expectedMessage = String.format(TankDeleteCommand.MESSAGE_DELETE_TANK_SUCCESS, tankToDelete);
 
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList(),
-                model.getTankList());
+                getTypicalTankList());
         expectedModel.deleteTank(tankToDelete);
         showNoTank(expectedModel);
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -7,6 +7,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_FISHES;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalFishes.ALICE;
 import static seedu.address.testutil.TypicalFishes.BENSON;
+import static seedu.address.testutil.TypicalTanks.getTypicalTankList;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
 
 import java.nio.file.Path;
@@ -101,8 +102,9 @@ public class ModelManagerTest {
         UserPrefs userPrefs = new UserPrefs();
 
         // same values -> returns true
-        modelManager = new ModelManager(addressBook, userPrefs, getTypicalTaskList(), new TankList());
-        ModelManager modelManagerCopy = new ModelManager(addressBook, userPrefs, getTypicalTaskList(), new TankList());
+        modelManager = new ModelManager(addressBook, userPrefs, getTypicalTaskList(), getTypicalTankList());
+        ModelManager modelManagerCopy = new ModelManager(addressBook, userPrefs, getTypicalTaskList(),
+                getTypicalTankList());
         assertTrue(modelManager.equals(modelManagerCopy));
 
         // same object -> returns true
@@ -116,13 +118,13 @@ public class ModelManagerTest {
 
         // different addressBook -> returns false
         assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs, getTypicalTaskList(),
-                new TankList())));
+                getTypicalTankList())));
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
         modelManager.updateFilteredFishList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs, getTypicalTaskList(),
-                new TankList())));
+                getTypicalTankList())));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredFishList(PREDICATE_SHOW_ALL_FISHES);
@@ -131,6 +133,6 @@ public class ModelManagerTest {
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs, getTypicalTaskList(),
-                new TankList())));
+                getTypicalTankList())));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalFishes.java
+++ b/src/test/java/seedu/address/testutil/TypicalFishes.java
@@ -10,8 +10,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_SPECIES_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SPECIES_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TANK_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TANK_BOB;
+import static seedu.address.testutil.TypicalTanks.TYPICAL_TANK_1_STRING;
+import static seedu.address.testutil.TypicalTanks.TYPICAL_TANK_2_STRING;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +19,8 @@ import java.util.List;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.fish.Fish;
+import seedu.address.model.tank.Tank;
+import seedu.address.model.tank.TankName;
 
 /**
  * A utility class containing a list of {@code Fish} objects to be used in tests.
@@ -28,37 +30,39 @@ public class TypicalFishes {
     public static final Fish ALICE = new FishBuilder().withName("Alice Pauline")
             .withFeedingInterval("1d1h").withSpecies("Guppy")
             .withLastFedDate("06/06/2003")
-            .withTank("tank 1")
+            .withTank(TYPICAL_TANK_1_STRING)
             .withTags("friends").build();
     public static final Fish BENSON = new FishBuilder().withName("Benson Meier")
             .withFeedingInterval("1d1h")
             .withSpecies("Tetra").withLastFedDate("06/07/2003")
-            .withTank("tank 1")
+            .withTank(TYPICAL_TANK_1_STRING)
             .withTags("owesMoney", "friends").build();
     public static final Fish CARL = new FishBuilder().withName("Carl Kurz").withLastFedDate("08/06/2003")
-            .withSpecies("Beta").withFeedingInterval("1d1h").withTank("tank 1").build();
+            .withSpecies("Beta").withFeedingInterval("1d1h").withTank(TYPICAL_TANK_1_STRING).build();
     public static final Fish DANIEL = new FishBuilder().withName("Daniel Meier").withLastFedDate("09/06/2003")
-            .withSpecies("Parrot").withFeedingInterval("1d1h").withTank("tank 1").withTags("friends").build();
+            .withSpecies("Parrot").withFeedingInterval("1d1h").withTank(TYPICAL_TANK_1_STRING).withTags("friends")
+            .build();
     public static final Fish ELLE = new FishBuilder().withName("Elle Meyer").withLastFedDate("10/06/2003")
-            .withSpecies("Arowana").withFeedingInterval("1d1h").withTank("tank 1").build();
+            .withSpecies("Arowana").withFeedingInterval("1d1h").withTank(TYPICAL_TANK_1_STRING).build();
     public static final Fish FIONA = new FishBuilder().withName("Fiona Kunz").withLastFedDate("11/06/2003")
-            .withSpecies("Fighting").withFeedingInterval("1d1h").withTank("tank 1").build();
+            .withSpecies("Fighting").withFeedingInterval("1d1h").withTank(TYPICAL_TANK_1_STRING).build();
     public static final Fish GEORGE = new FishBuilder().withName("George Best").withLastFedDate("12/06/2003")
-            .withSpecies("Beta").withFeedingInterval("1d1h").withTank("tank 1").build();
+            .withSpecies("Beta").withFeedingInterval("1d1h").withTank(TYPICAL_TANK_1_STRING).build();
 
     // Manually added
     public static final Fish HOON = new FishBuilder().withName("Hoon Meier").withLastFedDate("01/01/2000")
-            .withSpecies("Guppy").withFeedingInterval("0d19h").withTank("tank 1").build();
+            .withSpecies("Guppy").withFeedingInterval("0d19h").withTank(TYPICAL_TANK_1_STRING).build();
     public static final Fish IDA = new FishBuilder().withName("Ida Mueller").withLastFedDate("01/01/2000")
-            .withSpecies("Tetra").withFeedingInterval("0d20h").withTank("tank 1").build();
+            .withSpecies("Tetra").withFeedingInterval("0d20h").withTank(TYPICAL_TANK_1_STRING).build();
 
     // Manually added - Fish's details found in {@code CommandTestUtil}
     public static final Fish AMY = new FishBuilder().withName(VALID_NAME_AMY).withLastFedDate(VALID_LAST_FED_DATE_AMY)
-            .withSpecies(VALID_SPECIES_AMY).withFeedingInterval(VALID_FEEDING_INTERVAL_AMY).withTank(VALID_TANK_AMY)
+            .withSpecies(VALID_SPECIES_AMY).withFeedingInterval(VALID_FEEDING_INTERVAL_AMY)
+            .withTank(TYPICAL_TANK_1_STRING)
             .withTags(VALID_TAG_FRIEND).build();
     public static final Fish BOB = new FishBuilder().withName(VALID_NAME_BOB).withLastFedDate(VALID_LAST_FED_DATE_BOB)
             .withSpecies(VALID_SPECIES_BOB).withFeedingInterval(VALID_FEEDING_INTERVAL_BOB)
-            .withTank(VALID_TANK_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withTank(TYPICAL_TANK_2_STRING).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
@@ -71,6 +75,8 @@ public class TypicalFishes {
     public static AddressBook getTypicalAddressBook() {
         AddressBook ab = new AddressBook();
         for (Fish fish : getTypicalFishes()) {
+            //For testing purposes, ensure the tanks of Typical Fish is not changed by other tests
+            fish.setTank(new Tank(new TankName(TYPICAL_TANK_1_STRING), new AddressBook()));
             ab.addFish(fish);
         }
         return ab;

--- a/src/test/java/seedu/address/testutil/TypicalTanks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTanks.java
@@ -16,7 +16,8 @@ public class TypicalTanks {
     public static final Tank TANK_A = new TankBuilder().withTankName("Tank A").build();
     public static final Tank TANK_B = new TankBuilder().withTankName("Tank B").build();
     public static final Tank TANK_C = new TankBuilder().withTankName("Tank C").build();
-
+    public static final String TYPICAL_TANK_1_STRING = "Saltwater Tank 1";
+    public static final String TYPICAL_TANK_2_STRING = "Freshwater Tank 3";
     //To be added later in test class JsonTankListStorageTest
     public static final Tank TANK_D = new TankBuilder().withTankName("Tank D").build();
     public static final Tank TANK_E = new TankBuilder().withTankName("Tank E").build();
@@ -35,8 +36,8 @@ public class TypicalTanks {
     }
 
     public static List<Tank> getTypicalTanks() {
-        Tank tankOne = new Tank(new TankName("Saltwater Tank 1"), new AddressBook());
-        Tank tankTwo = new Tank(new TankName("Freshwater Tank 3"), new AddressBook());
+        Tank tankOne = new Tank(new TankName(TYPICAL_TANK_1_STRING), new AddressBook());
+        Tank tankTwo = new Tank(new TankName(TYPICAL_TANK_2_STRING), new AddressBook());
         return new ArrayList<>(Arrays.asList(tankOne, tankTwo));
     }
 


### PR DESCRIPTION
A fish's Tank attribute and a Tank's addressbook attribute's
individual Fishes points to duplicate copy instances with the same
attribute names.

They should be pointing to the actual instance i.e. A fish instance
in the main AddressBook should be the exact same instance of a Fish
in a Tank's AddressBook.
