### PR TITLE
Update Sorting to include sorting by tanks

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -287,8 +287,8 @@ Specifically, it currently sorts by the five compulsory fields of a fish:
 * Tank
 
 Currently, upon instantiation of `ModelManager`, it creates a `Filteredlist` from a `AddressBook`. Similarly,
-a `SortedList` is created based off the same `AddressBook`. Hence, when we perform sorting operations, we are able to manipulate
-the original list. As a result, `SortedList` has a separate panel from `FilteredList` and `Tank`.
+a `SortedList` is created based off the same `Filteredlist`. Hence, when we perform sorting operations, we are able to manipulate
+the filtered list. As a result, `SortedList` has a separate panel from `FilteredList` and `Tank`.
 
 Given below is an example usage scenario and how the sort mechanism behaves at each step.
 

--- a/src/main/java/seedu/address/logic/commands/fish/FishSortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/fish/FishSortCommand.java
@@ -1,14 +1,21 @@
 package seedu.address.logic.commands.fish;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_BY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TANK;
+import static seedu.address.model.Model.SHOW_FISHES_IN_TANK;
 
 import java.util.Comparator;
+import java.util.List;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.fish.Fish;
+import seedu.address.model.tank.Tank;
 
 /**
  * Sorts {@code Fish} using an attribute from the given {@code FishList}.
@@ -17,28 +24,48 @@ public class FishSortCommand extends FishCommand {
     public static final String FISH_COMMAND_WORD = "sort";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + FISH_COMMAND_WORD
-            + ": Sorts the Fish by the given attribute in the displayed Fish List.\n"
-            + "Parameters: n/lfd/s/fi/tk (must be a valid fish parameter)\n"
-            + "Example: " + COMMAND_WORD + " " + FISH_COMMAND_WORD + " lfd";
+            + ": Sorts the fish list by the given attribute.\n"
+            + "Parameters: "
+            + PREFIX_SORT_BY + "ATTRIBUTE "
+            + "[" + PREFIX_TANK + "TANK INDEX]...\n"
+            + "Example: " + COMMAND_WORD + " " + FISH_COMMAND_WORD + " "
+            + PREFIX_SORT_BY + "lfd"
+            + PREFIX_TANK + "1\n"
+            + "Sorting Options: n/lfd/s/fi/tk";
 
     public static final String MESSAGE_VIEW_FISH_SUCCESS = "Showing sorted Fish";
 
     private final Comparator<Fish> fishComparator;
+    private final Index tankIndex;
 
     /**
      * Constructs an {@code FishSortCommand} to view an existing {@code Tank}.
      *
      * @param fishComparator The index of the {@code Fish} to view.
+     * @param tankIndex Optional tankIndex to sort by specified tank.
      */
-    public FishSortCommand(Comparator<Fish> fishComparator) {
+    public FishSortCommand(Comparator<Fish> fishComparator, Index tankIndex) {
         requireNonNull(fishComparator);
         this.fishComparator = fishComparator;
+        this.tankIndex = tankIndex;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.sortFilteredFishList(fishComparator);
+
+        // If optional tank index was given, display sorting by tank
+        if (tankIndex != null) {
+            List<Tank> lastShownList = model.getFilteredTankList();
+            if (tankIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_TANK_DISPLAYED_INDEX);
+            }
+            Tank tankToView = lastShownList.get(tankIndex.getZeroBased());
+            // display filtered fish only
+            model.updateFilteredFishList(SHOW_FISHES_IN_TANK.apply(tankToView));
+        }
+
         model.setGuiMode(GuiSettings.GuiMode.DISPLAY_SORTED_FISHES_TASKS);
         return new CommandResult(MESSAGE_VIEW_FISH_SUCCESS, false, false, true);
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,6 +12,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_FEEDING_INTERVAL = new Prefix("fi/");
     public static final Prefix PREFIX_TAG = new Prefix("tg/");
     public static final Prefix PREFIX_TANK = new Prefix("tk/");
+    public static final Prefix PREFIX_SORT_BY = new Prefix("by/");
 
     /* Task prefixes */
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");

--- a/src/main/java/seedu/address/logic/parser/fish/FishSortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/fish/FishSortCommandParser.java
@@ -1,12 +1,20 @@
 package seedu.address.logic.parser.fish;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_BY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TANK;
 
 import java.util.Comparator;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.fish.FishSortCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.fish.Fish;
 
@@ -39,23 +47,44 @@ public class FishSortCommandParser implements Parser<FishSortCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FishSortCommand parse(String args) throws ParseException {
-        if (args.isEmpty()) {
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_SORT_BY, PREFIX_TANK);
+        if (!arePrefixesPresent(argMultimap, PREFIX_SORT_BY)
+                || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FishSortCommand.MESSAGE_USAGE));
         }
-        switch (args.trim().toLowerCase()) {
+        // Checks for a value, skips if no tankIndex was given
+        String index = argMultimap.getValue(PREFIX_TANK).orElse(null);
+        Index tankIndex = null;
+        if (index != null) {
+            tankIndex = ParserUtil.parseIndex(index);
+        }
+
+        String sortBy = argMultimap.getValue(PREFIX_SORT_BY).get();
+
+        switch (sortBy) {
         case "n":
-            return new FishSortCommand(NAME_COMPARATOR);
+            return new FishSortCommand(NAME_COMPARATOR, tankIndex);
         case "lfd":
-            return new FishSortCommand(LAST_FED_COMPARATOR);
+            return new FishSortCommand(LAST_FED_COMPARATOR, tankIndex);
         case "s":
-            return new FishSortCommand(SPECIES_COMPARATOR);
+            return new FishSortCommand(SPECIES_COMPARATOR, tankIndex);
         case "fi":
-            return new FishSortCommand(FEEDING_COMPARATOR);
+            return new FishSortCommand(FEEDING_COMPARATOR, tankIndex);
         case "tk":
-            return new FishSortCommand(TANK_COMPARATOR);
+            return new FishSortCommand(TANK_COMPARATOR, tankIndex);
         default:
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                     FishSortCommand.MESSAGE_USAGE));
         }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -46,7 +46,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredFish = new FilteredList<>(this.addressBook.getFishList());
-        sortedFish = new SortedList<>(this.addressBook.getFishList());
+        sortedFish = new SortedList<>(filteredFish);
         this.taskList = new TaskList(taskList);
         filteredTasks = new FilteredList<>(this.taskList.getTaskList());
         this.tankList = new TankList(tankList);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FEEDING_INTERVAL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LAST_FED_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_BY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPECIES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TANK;
@@ -30,11 +31,11 @@ import seedu.address.testutil.EditFishDescriptorBuilder;
 public class CommandTestUtil {
 
     /* Sorting */
-    public static final String SORT_NAME = "n";
-    public static final String SORT_LAST_FED_DATE = "lfd";
-    public static final String SORT_SPECIES = "s";
-    public static final String SORT_FEEDING = "fi";
-    public static final String SORT_TANK = "tk";
+    public static final String SORT_NAME = " " + PREFIX_SORT_BY + "n";
+    public static final String SORT_LAST_FED_DATE = " " + PREFIX_SORT_BY + "lfd";
+    public static final String SORT_SPECIES = " " + PREFIX_SORT_BY + "s";
+    public static final String SORT_FEEDING = " " + PREFIX_SORT_BY + "fi";
+    public static final String SORT_TANK = " " + PREFIX_SORT_BY + "tk";
 
     /* Tank additions */
     public static final String VALID_TANK_INDEX = "1";

--- a/src/test/java/seedu/address/logic/commands/fish/FishSortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/fish/FishSortCommandTest.java
@@ -11,12 +11,12 @@ import seedu.address.model.fish.Fish;
 public class FishSortCommandTest {
     @Test
     public void constructor_nullComparator_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new FishSortCommand(null));
+        assertThrows(NullPointerException.class, () -> new FishSortCommand(null, null));
     }
 
     @Test
     public void execute_nullModel_throwsNullPointerException() {
         Comparator<Fish> validComp = (o1, o2) -> 0;
-        assertThrows(NullPointerException.class, () -> new FishSortCommand(validComp).execute(null));
+        assertThrows(NullPointerException.class, () -> new FishSortCommand(validComp, null).execute(null));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FishSortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FishSortCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.SORT_LAST_FED_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.SORT_NAME;
 import static seedu.address.logic.commands.CommandTestUtil.SORT_SPECIES;
 import static seedu.address.logic.commands.CommandTestUtil.SORT_TANK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_BY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -19,11 +20,16 @@ public class FishSortCommandParserTest {
     private final FishSortCommandParser parser = new FishSortCommandParser();
     @Test
     public void parse_allScenarios_success() {
-        assertParseSuccess(parser, SORT_NAME, new FishSortCommand(FishSortCommandParser.NAME_COMPARATOR));
-        assertParseSuccess(parser, SORT_LAST_FED_DATE, new FishSortCommand(FishSortCommandParser.LAST_FED_COMPARATOR));
-        assertParseSuccess(parser, SORT_SPECIES, new FishSortCommand(FishSortCommandParser.SPECIES_COMPARATOR));
-        assertParseSuccess(parser, SORT_FEEDING, new FishSortCommand(FishSortCommandParser.FEEDING_COMPARATOR));
-        assertParseSuccess(parser, SORT_TANK, new FishSortCommand(FishSortCommandParser.TANK_COMPARATOR));
+        assertParseSuccess(parser, SORT_NAME,
+                new FishSortCommand(FishSortCommandParser.NAME_COMPARATOR, null));
+        assertParseSuccess(parser, SORT_LAST_FED_DATE,
+                new FishSortCommand(FishSortCommandParser.LAST_FED_COMPARATOR, null));
+        assertParseSuccess(parser, SORT_SPECIES,
+                new FishSortCommand(FishSortCommandParser.SPECIES_COMPARATOR, null));
+        assertParseSuccess(parser, SORT_FEEDING,
+                new FishSortCommand(FishSortCommandParser.FEEDING_COMPARATOR, null));
+        assertParseSuccess(parser, SORT_TANK,
+                new FishSortCommand(FishSortCommandParser.TANK_COMPARATOR, null));
     }
 
     @Test
@@ -31,7 +37,7 @@ public class FishSortCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FishSortCommand.MESSAGE_USAGE);
 
         // missing input
-        assertParseFailure(parser, " ", expectedMessage);
+        assertParseFailure(parser, " " + PREFIX_SORT_BY + " ", expectedMessage);
     }
 
     @Test
@@ -39,15 +45,15 @@ public class FishSortCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FishSortCommand.MESSAGE_USAGE);
 
         // extra character
-        assertParseFailure(parser, "lfdd", expectedMessage);
+        assertParseFailure(parser, " " + PREFIX_SORT_BY + "lfdd", expectedMessage);
 
         // missing character
-        assertParseFailure(parser, "lf", expectedMessage);
+        assertParseFailure(parser, " " + PREFIX_SORT_BY + "lf", expectedMessage);
 
         // invalid character
-        assertParseFailure(parser, "@", expectedMessage);
+        assertParseFailure(parser, " " + PREFIX_SORT_BY + "@", expectedMessage);
 
         // integer character
-        assertParseFailure(parser, "-1", expectedMessage);
+        assertParseFailure(parser, " " + PREFIX_SORT_BY + "-1", expectedMessage);
     }
 }


### PR DESCRIPTION
Sorting now uses prefixes to have a fish attribute to sort by and an optional tank index to display. By changing the SortedList to wrap the original FilteredList, we are able to utilize the methods for the original FilteredList to filter and display by tanks.