### PR TITLE
Fix listing all fishes after add or edit fish

### DIFF
--- a/src/main/java/seedu/address/logic/commands/fish/FishEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/fish/FishEditCommand.java
@@ -96,7 +96,6 @@ public class FishEditCommand extends FishCommand {
             fishToEdit.getTank().getFishList().setFish(fishToEdit, editedFish);
         }
 
-        //model.updateFilteredFishList(PREDICATE_SHOW_ALL_FISHES);
         return new CommandResult(String.format(MESSAGE_EDIT_FISH_SUCCESS, editedFish));
     }
 

--- a/src/main/java/seedu/address/logic/commands/fish/FishEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/fish/FishEditCommand.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPECIES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TANK;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_FISHES;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -83,8 +82,6 @@ public class FishEditCommand extends FishCommand {
 
         Fish fishToEdit = lastShownList.get(index.getZeroBased());
         Fish editedFish = createEditedFish(fishToEdit, editFishDescriptor, model);
-        //editedFish's tank attribute is only an index
-        //        editedFish.setTank(tank);
 
         if (!fishToEdit.isSameFish(editedFish) && model.hasFish(editedFish)) {
             throw new CommandException(MESSAGE_DUPLICATE_FISH);
@@ -99,7 +96,7 @@ public class FishEditCommand extends FishCommand {
             fishToEdit.getTank().getFishList().setFish(fishToEdit, editedFish);
         }
 
-        model.updateFilteredFishList(PREDICATE_SHOW_ALL_FISHES);
+        //model.updateFilteredFishList(PREDICATE_SHOW_ALL_FISHES);
         return new CommandResult(String.format(MESSAGE_EDIT_FISH_SUCCESS, editedFish));
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -224,8 +224,6 @@ public class ModelManager implements Model {
     @Override
     public void addFish(Fish fish) {
         addressBook.addFish(fish);
-        updateFilteredFishList(PREDICATE_SHOW_ALL_FISHES);
-
     }
 
     @Override


### PR DESCRIPTION
When fish edit or fish add is called after tank view, all fishes will be shown. 
updateFilteredFishLIst(show_all_fishes_predicate) is unecessarily called

Let's remove this unintended feature