### PR TITLE
Fix data files other than addressbook corruption not working

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -121,7 +121,7 @@ public class MainApp extends Application {
         return new ModelManager(initialData, userPrefs, initialTaskList, initialTankList, initialFullReadings);
     }
 
-    private ReadOnlyAddressBook readAddressBookFromStorage(Storage storage) throws  DataConversionException,
+    private ReadOnlyAddressBook readAddressBookFromStorage(Storage storage) throws DataConversionException,
             IOException {
         Optional<ReadOnlyAddressBook> addressBookOptional;
         ReadOnlyAddressBook initialData;
@@ -133,7 +133,7 @@ public class MainApp extends Application {
         return initialData;
     }
 
-    private ReadOnlyTaskList readTaskListFromStorage(Storage storage) throws  DataConversionException,
+    private ReadOnlyTaskList readTaskListFromStorage(Storage storage) throws DataConversionException,
             IOException {
         Optional<ReadOnlyTaskList> taskListOptional;
         ReadOnlyTaskList initialData;
@@ -145,7 +145,7 @@ public class MainApp extends Application {
         return initialData;
     }
 
-    private ReadOnlyTankList readTankListFromStorage(Storage storage) throws  DataConversionException,
+    private ReadOnlyTankList readTankListFromStorage(Storage storage) throws DataConversionException,
             IOException {
         Optional<ReadOnlyTankList> tankListOptional;
         ReadOnlyTankList initialData;
@@ -157,7 +157,7 @@ public class MainApp extends Application {
         return initialData;
     }
 
-    private ReadOnlyReadingLevels readReadingLevelsFromStorage(Storage storage) throws  DataConversionException,
+    private ReadOnlyReadingLevels readReadingLevelsFromStorage(Storage storage) throws DataConversionException,
             IOException {
         Optional<ReadOnlyReadingLevels> readingLevelsOptional;
         ReadOnlyReadingLevels initialData;

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -74,10 +74,10 @@ public class MainApp extends Application {
         AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookFilePath());
         TaskListStorage taskListStorage = new JsonTaskListStorage(userPrefs.getTaskListFilePath());
         TankListStorage tankListStorage = new JsonTankListStorage(userPrefs.getTankListFilePath());
-        FullReadingLevelsStorage ammoniaLevelsStorage = new JsonFullReadingLevelsStorage(userPrefs
-                .getFullAmmoniaLevelsPath());
+        FullReadingLevelsStorage fullReadingLevelsStorage = new JsonFullReadingLevelsStorage(userPrefs
+                .getFullReadingsLevelsPath());
         storage = new StorageManager(addressBookStorage, userPrefsStorage, taskListStorage, tankListStorage,
-                ammoniaLevelsStorage);
+                fullReadingLevelsStorage);
 
         initLogging(config);
 
@@ -94,71 +94,79 @@ public class MainApp extends Application {
      * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
-        Optional<ReadOnlyAddressBook> addressBookOptional;
         ReadOnlyAddressBook initialData;
-        try {
-            addressBookOptional = storage.readAddressBook();
-            if (!addressBookOptional.isPresent()) {
-                logger.info("Data file not found. Will be starting with a sample AddressBook");
-            }
-            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
-        } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
-            initialData = new AddressBook();
-        } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
-            initialData = new AddressBook();
-        }
-
-        Optional<ReadOnlyTaskList> taskListOptional;
         ReadOnlyTaskList initialTaskList;
-        try {
-            taskListOptional = storage.readTaskList();
-            if (taskListOptional.isEmpty()) {
-                logger.info("Data file not found. Will be starting with a sample TaskList");
-            }
-            initialTaskList = taskListOptional.orElseGet(SampleTaskUtil::getSampleTaskList);
-        } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty TaskList");
-            initialTaskList = new TaskList();
-        } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty TaskList");
-            initialTaskList = new TaskList();
-        }
-
-        Optional<ReadOnlyTankList> tankListOptional;
         ReadOnlyTankList initialTankList;
-        try {
-            tankListOptional = storage.readTankList();
-            if (tankListOptional.isEmpty()) {
-                logger.info("Data file not found. Will be starting with a sample TankList");
-            }
-            initialTankList = tankListOptional.orElseGet(SampleTankUtil::getSampleTankList);
-        } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty TankList");
-            initialTankList = new TankList();
-        } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty TankList");
-            initialTankList = new TankList();
-        }
-
-        Optional<ReadOnlyReadingLevels> fullReadingsOptional;
         ReadOnlyReadingLevels initialFullReadings;
+
         try {
-            fullReadingsOptional = storage.readFullReadingLevels();
-            if (fullReadingsOptional.isEmpty()) {
-                logger.info("Data file not found. Will be starting with a sample Readings");
-            }
-            initialFullReadings = fullReadingsOptional.orElseGet(SampleReadingsUtil::getSampleFullReadingLevels);
+            initialData = readAddressBookFromStorage(storage);
+            initialTaskList = readTaskListFromStorage(storage);
+            initialTankList = readTankListFromStorage(storage);
+            initialFullReadings = readReadingLevelsFromStorage(storage);
         } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty Readings set");
+            logger.warning("Data file not in the correct format. Will be starting with an empty Files");
+            initialData = new AddressBook();
+            initialTaskList = new TaskList();
+            initialTankList = new TankList();
             initialFullReadings = new FullReadingLevels();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty Readings set");
+            logger.warning("Problem while reading from the file. Will be starting with an empty Files");
+            initialData = new AddressBook();
+            initialTaskList = new TaskList();
+            initialTankList = new TankList();
             initialFullReadings = new FullReadingLevels();
         }
 
         return new ModelManager(initialData, userPrefs, initialTaskList, initialTankList, initialFullReadings);
+    }
+
+    private ReadOnlyAddressBook readAddressBookFromStorage(Storage storage) throws  DataConversionException,
+            IOException {
+        Optional<ReadOnlyAddressBook> addressBookOptional;
+        ReadOnlyAddressBook initialData;
+        addressBookOptional = storage.readAddressBook();
+        if (!addressBookOptional.isPresent()) {
+            logger.info("Data file not found. Will be starting with a sample AddressBook");
+        }
+        initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
+        return initialData;
+    }
+
+    private ReadOnlyTaskList readTaskListFromStorage(Storage storage) throws  DataConversionException,
+            IOException {
+        Optional<ReadOnlyTaskList> taskListOptional;
+        ReadOnlyTaskList initialData;
+        taskListOptional = storage.readTaskList();
+        if (!taskListOptional.isPresent()) {
+            logger.info("Data file not found. Will be starting with a sample Task List");
+        }
+        initialData = taskListOptional.orElseGet(SampleTaskUtil::getSampleTaskList);
+        return initialData;
+    }
+
+    private ReadOnlyTankList readTankListFromStorage(Storage storage) throws  DataConversionException,
+            IOException {
+        Optional<ReadOnlyTankList> tankListOptional;
+        ReadOnlyTankList initialData;
+        tankListOptional = storage.readTankList();
+        if (!tankListOptional.isPresent()) {
+            logger.info("Data file not found. Will be starting with a sample Tank List");
+        }
+        initialData = tankListOptional.orElseGet(SampleTankUtil::getSampleTankList);
+        return initialData;
+    }
+
+    private ReadOnlyReadingLevels readReadingLevelsFromStorage(Storage storage) throws  DataConversionException,
+            IOException {
+        Optional<ReadOnlyReadingLevels> readingLevelsOptional;
+        ReadOnlyReadingLevels initialData;
+        readingLevelsOptional = storage.readFullReadingLevels();
+        if (!readingLevelsOptional.isPresent()) {
+            logger.info("Data file not found. Will be starting with a sample Reading levels");
+        }
+        initialData = readingLevelsOptional.orElseGet(SampleReadingsUtil::getSampleFullReadingLevels);
+        return initialData;
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -17,7 +17,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
     private Path taskListFilePath = Paths.get("data" , "tasklist.json");
     private Path tankListFilePath = Paths.get("data", "tanklist.json");
-    private Path fullAmmoniaLevelsPath = Paths.get("data", "readings.json");
+    private Path fullReadingsLevelsPath = Paths.get("data", "readings.json");
     /**
      * Creates a {@code UserPrefs} with default values.
      */
@@ -79,13 +79,13 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.tankListFilePath = tankListFilePath;
     }
 
-    public Path getFullAmmoniaLevelsPath() {
-        return fullAmmoniaLevelsPath;
+    public Path getFullReadingsLevelsPath() {
+        return fullReadingsLevelsPath;
     }
 
-    public void setFullAmmoniaLevelsPath(Path fullAmmoniaLevelsPath) {
-        requireNonNull(fullAmmoniaLevelsPath);
-        this.fullAmmoniaLevelsPath = fullAmmoniaLevelsPath;
+    public void setFullReadingsLevelsPath(Path fullReadingsLevelsPath) {
+        requireNonNull(fullReadingsLevelsPath);
+        this.fullReadingsLevelsPath = fullReadingsLevelsPath;
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -170,7 +170,7 @@ public class StorageManager implements Storage {
 
     @Override
     public Optional<ReadOnlyReadingLevels> readFullReadingLevels(Path filePath)
-            throws DataConversionException, IOException {
+            throws DataConversionException {
         logger.fine("Attempting to read data from file: " + filePath);
         return fullReadingLevelsStorage.readFullReadingLevels(filePath);
     }

--- a/src/main/java/seedu/address/storage/tank/readings/ammonialevels/JsonAdaptedIndividualReadingLevels.java
+++ b/src/main/java/seedu/address/storage/tank/readings/ammonialevels/JsonAdaptedIndividualReadingLevels.java
@@ -19,6 +19,8 @@ public class JsonAdaptedIndividualReadingLevels {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Tank's %s field is missing!";
 
+    public static final String MESSAGE_CORRUPTED_READINGS = "Some readings data is corrupted";
+
     private final String tankName;
 
     private final String commaSeperatedValuesAmmonia;
@@ -88,6 +90,16 @@ public class JsonAdaptedIndividualReadingLevels {
         }
         final TankName modelTankName = new TankName(tankName);
         Tank tank = new Tank(modelTankName, new AddressBook(), new UniqueIndividualReadingLevels());
+
+        boolean hasCorruptedData = commaSeperatedDatesAmmonia == null
+                || commaSeperatedDatesPH == null
+                || commaSeperatedDatesTemp == null
+                || commaSeperatedValuesAmmonia == null
+                || commaSeperatedValuesPH == null
+                || commaSeperatedValuesTemp == null;
+        if (hasCorruptedData) {
+            throw new IllegalValueException(MESSAGE_CORRUPTED_READINGS);
+        }
 
         String[] valuesAmmonia = commaSeperatedValuesAmmonia.split(",");
         String[] datesAmmonia = commaSeperatedDatesAmmonia.split(",");


### PR DESCRIPTION
If json fields in data files other than addressbook is corrupted i.e. tankNames become ankNames, a null pointer exception will occur

In our UG it states that fresh data will be loaded. Following addressbook's original implementation, Empty fish lists, tank lists, task lists and readings lists are intended to be created and a completely empty fish ahoy should open. 

Fix a null pointer exception being thrown instead of a fresh fish ahoy being opened and also increase SLAP in MainApp