### PR TITLE
Fix task no duplicate check and update UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -731,6 +731,9 @@ Parameters:
 > :information_source: Additional information: Can't seem to see your newly added tasks? Ensure you are not limiting
 > your tasks to a specific tank with the `list tasks` command!
 
+> :exclamation: Warning: Within the same tank (two tasks that both do not have a tank attached are considered to be in the same tank)
+>, you cannot have tasks with the same name!
+
 Example:
 * You have 'Clean tank' with no priority in your task panel. `task add d/Feed fish p/high` will display the
 following tasks in your task panel:
@@ -780,6 +783,9 @@ Parameters:
 
 > :exclamation: Warning: Feeding reminders are automated and managed by *Fish Ahoy!* so you cannot
 > edit a feeding reminder
+
+> :exclamation: Warning: As mentioned, you cannot have 2 tasks of the same name, with the same tank as they are duplicates. You cannot edit
+> a task's tank if it will cause a duplicate task!
 
 Example:
 * You have a task with description 'Clean tank' of index 1, and it is attached to 'freshwater tank'. `task edit 1 d/clean tank again` will change the task to have the following details:
@@ -845,7 +851,9 @@ App data are saved as a JSON file `[JAR file location]/data/fishahoy.json`. Adva
 > :bulb: Tip: If you have a set of ammonia, pH and temperature readings you want to input in bulk,
 you might want to insert it directly in the `readings.json` file!
 
-> :exclamation: Warning: If your changes to the data file makes its format invalid, *Fish Ahoy!* will discard all data and start with an empty data file at the next run
+> :exclamation: Warning: If your changes to the data file makes its format invalid, *Fish Ahoy!* will discard all data and start with an empty data file at the next run.
+> This will result in a completely empty interface. Delete your `data` folder, containing `addressbook.json` and so on
+> to revert back to the default *Fish Ahoy!*
 
 ## Help
 ### Viewing help : `help`

--- a/src/main/java/seedu/address/logic/commands/task/TaskAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/TaskAddCommand.java
@@ -62,12 +62,12 @@ public class TaskAddCommand extends TaskCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        Tank tank = getTaskTank(tankIndex, model);
+        toAdd.setTank(tank);
+
         if (model.hasTask(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_TASK);
         }
-
-        Tank tank = getTaskTank(tankIndex, model);
-        toAdd.setTank(tank);
 
         model.addTask(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -80,7 +80,6 @@ public class Task {
         boolean bothHasTank = isTankRelatedTask() && otherTask.isTankRelatedTask();
         boolean bothNoTank = !isTankRelatedTask() && !otherTask.isTankRelatedTask();
         boolean hasSameTank = (bothHasTank && (tank.equals(otherTask.getTank()))) || bothNoTank;
-        System.out.println("here");
         return otherTask.getDescription().equals(description)
                 && hasSameTank;
     }

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -78,7 +78,9 @@ public class Task {
 
         Task otherTask = (Task) other;
         boolean bothHasTank = isTankRelatedTask() && otherTask.isTankRelatedTask();
-        boolean hasSameTank = bothHasTank && (tank.equals(otherTask.getTank()));
+        boolean bothNoTank = !isTankRelatedTask() && !otherTask.isTankRelatedTask();
+        boolean hasSameTank = (bothHasTank && (tank.equals(otherTask.getTank()))) || bothNoTank;
+        System.out.println("here");
         return otherTask.getDescription().equals(description)
                 && hasSameTank;
     }


### PR DESCRIPTION
I intended to disallow duplicate tasks within the same tank. I have fixed the bug where dupes of tasks with no tanks can be made and tasks of same name but different tanks cannot be added. Update DG also

Close #179 